### PR TITLE
Fix for chat messages not showing in macOS Ventura

### DIFF
--- a/Sources/Views/Cells/TextMessageItem.swift
+++ b/Sources/Views/Cells/TextMessageItem.swift
@@ -49,6 +49,7 @@ open class TextMessageItem: MessageCollectionViewItem {
         messageLabel.font = font
       }
       messageLabel.frame = messageContainerView.bounds.insetBy(attributes.messageLabelInsets)
+      messageLabel.translatesAutoresizingMaskIntoConstraints = true
     }
   }
   


### PR DESCRIPTION
Fix for chat messages not showing in macOS Ventura

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
An issue has been observed in macOS Ventura Beta release. The issues is chat messages are not seen in the bubbles, the message bubbles are just blank, bubbles do resize based on message length but the bubbles do not display the message itself. I am attempting to fix the issue by this PR.
<img width="240" alt="Screenshot 2022-09-22 at 12 59 11 PM" src="https://user-images.githubusercontent.com/74983161/191808418-d4883e70-4da8-4612-8b78-6d09cf914d2c.png">


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** MacBook Pro running macOS Ventura Beta OS

**iOS Version:** …

**Swift Version:** Latest

**MessageKit Version:**  Latest 

